### PR TITLE
Split solve function and return linsolver object

### DIFF
--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -534,7 +534,6 @@ class ACPF(PFmethod):
             raise PFmethodError_BadOptSolver()
         solver.set_parameters(solver_params[solver_name])
 
-
         # Callbacks
         def c1(s):
             if (s.k != 0 and params['tap_limits'] and tap_mode == self.CONTROL_MODE_REG and
@@ -609,6 +608,8 @@ class ACPF(PFmethod):
             self.set_solver_dual_variables(solver.get_dual_variables())
             self.set_problem(problem if save_problem else None)
             self.set_network_snapshot(net if not update_net else None)
+            if solver_name == 'nr':
+                self.set_linsolver(solver.linsolver)
 
     def solve(self, net, save_problem=False, update_net=False):
         """

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -503,7 +503,7 @@ class ACPF(PFmethod):
 
         return problem
 
-    def solve_problem(self, problem, save_problem=False, save_linsolver=False, update_net=False):
+    def solve_problem(self, problem, save_problem=False, update_net=False):
         """
         solve the Optimization problem
         """
@@ -610,9 +610,8 @@ class ACPF(PFmethod):
             self.set_solver_dual_variables(solver.get_dual_variables())
             self.set_problem(problem if save_problem else None)
             self.set_network_snapshot(net)
-            self.set_linsolver(solver.linsolver if solver_name == 'nr' and save_linsolver else None)
 
-    def solve(self, net, save_problem=False, save_linsolver=False, update_net=False):
+    def solve(self, net, save_problem=False, update_net=False):
         """
         Solve the network
 
@@ -627,7 +626,7 @@ class ACPF(PFmethod):
         problem = self.initialize_problem(net, update_net)
 
         # step 2: Solve the initialized optimization Problem
-        self.solve_problem(problem, save_problem, save_linsolver, update_net)
+        self.solve_problem(problem, save_problem, update_net)
 
     def get_info_printer(self):
 

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -501,9 +501,9 @@ class ACPF(PFmethod):
         problem_time = time.time()-t0
         self.set_problem_time(problem_time)
 
-        return problem
+        return net, problem
 
-    def solve_problem(self, problem, save_problem=False, update_net=False):
+    def solve_problem(self, net, problem, save_problem=False, update_net=False):
         """
         solve the Optimization problem
         """
@@ -574,9 +574,6 @@ class ACPF(PFmethod):
         info_printer = self.get_info_printer()
         solver.set_info_printer(info_printer)
 
-        # point to network
-        net = problem.network
-
         # Solve
         update = True
         t0 = time.time()
@@ -623,10 +620,10 @@ class ACPF(PFmethod):
         """
 
         # Step 1: initialize optimization Problem
-        problem = self.initialize_problem(net, update_net)
+        net, problem = self.initialize_problem(net, update_net)
 
         # step 2: Solve the initialized optimization Problem
-        self.solve_problem(problem, save_problem, update_net)
+        self.solve_problem(net, problem, save_problem, update_net)
 
     def get_info_printer(self):
 

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -503,7 +503,7 @@ class ACPF(PFmethod):
 
         return problem
 
-    def solve_problem(self, problem, save_problem=False, update_net=False):
+    def solve_problem(self, problem, save_problem=False, save_linsolver=False, update_net=False):
         """
         solve the Optimization problem
         """
@@ -610,10 +610,9 @@ class ACPF(PFmethod):
             self.set_solver_dual_variables(solver.get_dual_variables())
             self.set_problem(problem if save_problem else None)
             self.set_network_snapshot(net)
-            if solver_name == 'nr':
-                self.set_linsolver(solver.linsolver)
+            self.set_linsolver(solver.linsolver if solver_name == 'nr' and save_linsolver else None)
 
-    def solve(self, net, save_problem=False, update_net=False):
+    def solve(self, net, save_problem=False, save_linsolver=False, update_net=False):
         """
         Solve the network
 
@@ -628,7 +627,7 @@ class ACPF(PFmethod):
         problem = self.initialize_problem(net, update_net)
 
         # step 2: Solve the initialized optimization Problem
-        self.solve_problem(problem, save_problem, update_net)
+        self.solve_problem(problem, save_problem, save_linsolver, update_net)
 
     def get_info_printer(self):
 

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -481,7 +481,7 @@ class ACPF(PFmethod):
         # Return
         return problem
 
-    def initialize_problem(self, net, update_net):
+    def initialize_problem(self, net, update_net=False):
         # Parameters
         params = self._parameters
         v_min_clip = params['v_min_clip']
@@ -490,7 +490,8 @@ class ACPF(PFmethod):
         if not update_net:
             # Copy network
             net = net.get_copy(merge_buses=True)
-            self.set_network_snapshot(net)
+
+        self.set_network_snapshot(net)
 
         # Clipping
         for bus in net.buses:
@@ -607,7 +608,7 @@ class ACPF(PFmethod):
             self.set_solver_primal_variables(solver.get_primal_variables())
             self.set_solver_dual_variables(solver.get_dual_variables())
             self.set_problem(problem if save_problem else None)
-            self.set_network_snapshot(net if not update_net else None)
+            self.set_network_snapshot(net)
             if solver_name == 'nr':
                 self.set_linsolver(solver.linsolver)
 

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -491,8 +491,6 @@ class ACPF(PFmethod):
             # Copy network
             net = net.get_copy(merge_buses=True)
 
-        self.set_network_snapshot(net)
-
         # Clipping
         for bus in net.buses:
             bus.v_mag = np.minimum(np.maximum(bus.v_mag, v_min_clip), v_max_clip)
@@ -505,7 +503,7 @@ class ACPF(PFmethod):
 
         return problem
 
-    def solve_problem(self, net, problem, save_problem=False, update_net=False):
+    def solve_problem(self, problem, save_problem=False, update_net=False):
         """
         solve the Optimization problem
         """
@@ -576,6 +574,9 @@ class ACPF(PFmethod):
         info_printer = self.get_info_printer()
         solver.set_info_printer(info_printer)
 
+        # point to network
+        net = problem.network
+
         # Solve
         update = True
         t0 = time.time()
@@ -627,7 +628,7 @@ class ACPF(PFmethod):
         problem = self.initialize_problem(net, update_net)
 
         # step 2: Solve the initialized optimization Problem
-        self.solve_problem(net, problem, save_problem, update_net)
+        self.solve_problem(problem, save_problem, update_net)
 
     def get_info_printer(self):
 

--- a/gridopt/power_flow/method.py
+++ b/gridopt/power_flow/method.py
@@ -28,8 +28,7 @@ class PFmethod:
                         'solver dual variables': None,
                         'problem': None,
                         'problem time': 0.,
-                        'network snapshot': None,
-                        'linsolver': None}
+                        'network snapshot': None}
 
     def create_problem(self,net):
         """
@@ -79,16 +78,6 @@ class PFmethod:
         """
 
         self.results['solver name'] = name
-
-    def set_linsolver(self, linsolver):
-        """
-        Set the linsolver object
-
-        Parameters
-        ----------
-        linsolver : object
-        """
-        self.results['linsolver'] = linsolver
 
     def set_solver_status(self, status):
         """

--- a/gridopt/power_flow/method.py
+++ b/gridopt/power_flow/method.py
@@ -26,9 +26,10 @@ class PFmethod:
                         'solver time': 0.,
                         'solver primal variables': None,
                         'solver dual variables': None,
-                        'problem' : None,
-                        'problem time' : 0.,
-                        'network snapshot' : None}
+                        'problem': None,
+                        'problem time': 0.,
+                        'network snapshot': None,
+                        'linsolver': None}
 
     def create_problem(self,net):
         """
@@ -78,6 +79,16 @@ class PFmethod:
         """
 
         self.results['solver name'] = name
+
+    def set_linsolver(self, linsolver):
+        """
+        Set the linsolver object
+
+        Parameters
+        ----------
+        linsolver : object
+        """
+        self.results['linsolver'] = linsolver
 
     def set_solver_status(self, status):
         """


### PR DESCRIPTION
Hey @awig,

Please check out the updates from this branch. 
## Background:
I am interested in limiting doing the same calculation twice and also minimizing copying the network, etc. This calculation may seem fast for one run, but it increases the execution time for thousands of contingencies. 

I want to avoid copying the network and return the linsolver (in case solver == nr, the results will have linsolver object)

Basically, The function self.solve(net, save_problem)  is split into two functions: 1- creating the problem, 2- solve the problem.


The following are the way I used to run the analysis and the new way (pseudo code)

 ```
# Old code
for each contingency:
       c.apply(net)
       run power flow              # Copy of net
       get the snapshot  to do other analysis
       c.clear(net)

       # Calculate sensitivity 
       form jacobian using snapshot
       linsolver >> analyze, factorize  jacobian   # unnecessary 

      linsolver.solve(b)
```

The new way:
```
for each contingency:
       c.apply(net)
       formulate nr_problem  (Step 1)
       x_var = net.get_var_values()
       solve (nr_problem, update_net=True)   # Work on the same network
       
       Do all the analysis on the same network 

       # Calculate sensitivity 
       linsolver = PF_method.get_results()['linsolver']    # from NR 
      linsolver.solve(b)         # No analysis and factorizition of the jacobian matrix, get the results from the last iteration of PF

      net.set_var_values(x_var)    # Reset var values to get the original the network 
      c.clear(net)

```

