### PR TITLE
add FACTS CV and CZ control constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Verions 1.4.1
 * Added `load_q_curtail` parameter setting to ACPF that allows for load.Q to deviate.
 * Change `gens_redispatch` as True that forced changing slack to redispatchable.
 * Separate ACPF.solve into steps for `initialize_problem` and `solve_problem` in order to reduce computation time with contructing the problem for contingencies or other calculations where the problem construction does not change.
+* Add FACTS constraints with for series voltage control and series impedance control.
 
 Version 1.4.0
 -------------

--- a/gridopt/power_flow/ac_pf.py
+++ b/gridopt/power_flow/ac_pf.py
@@ -241,6 +241,8 @@ class ACPF(PFmethod):
         problem.add_constraint(pfnet.Constraint('switching power factor regulation', net))
         problem.add_constraint(pfnet.Constraint('switching FACTS active power control', net))
         problem.add_constraint(pfnet.Constraint('switching FACTS reactive power control', net))
+        problem.add_constraint(pfnet.Constraint('switching FACTS series voltage control', net))
+        problem.add_constraint(pfnet.Constraint('switching FACTS series impedance control', net))
 
         if vdep_loads:
             problem.add_constraint(pfnet.Constraint('load voltage dependence', net))
@@ -436,6 +438,8 @@ class ACPF(PFmethod):
         problem.add_constraint(pfnet.Constraint('VSC DC voltage control', net))
         problem.add_constraint(pfnet.Constraint('CSC DC voltage control', net))
         problem.add_constraint(pfnet.Constraint('power factor regulation', net))
+        problem.add_constraint(pfnet.Constraint('switching FACTS series voltage control', net))
+        problem.add_constraint(pfnet.Constraint('switching FACTS series impedance control', net))
 
         if lock_vsc_P_dc:
             problem.add_constraint(pfnet.Constraint('VSC DC power control', net))


### PR DESCRIPTION
## Issue
Modeling on FACTS in CV, CZ modes is done in PFNET, PFNET.py, and raw parser. This PR is to add the constraints to NR and Opt-based for those types of FACTS.

## Tests
- No test added to GRIDOPT
- 2 test cases in PFNET.py